### PR TITLE
Mobile Fix, community images upgrade

### DIFF
--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -149,6 +149,10 @@ p {
 ul,
 ol {
   line-height: 1.6em;
+	/*Fix Horizontal Scrolling for getting started page on smaller screens*/
+  word-break: break-all;
+	word-break: break-word;
+	
   margin: 0 0 30px 0;
 }
 blockquote {
@@ -909,10 +913,13 @@ progress::-webkit-progress-value { background: 00AB1F; }
 }
 /* END Bootstrap fix*/
 
+
 .profile-img {
-  border: 1px solid #333;
-  padding: 3px;
   float: left;
   width: 125px;
   margin-right: 8px;
+	/*Added a bit more style, to community images*/
+	    border-radius: 8px;
+    border: 5px solid #27a01f;
+    box-shadow: -1px 1px 2px #000;
 }


### PR DESCRIPTION
Fixed the mobile for getting started page by adding word wrap, also added small green border around community images, with clean box shadow and rounded corner.